### PR TITLE
Add architecture documentation and refresh README

### DIFF
--- a/docs/high_level_design.md
+++ b/docs/high_level_design.md
@@ -1,0 +1,129 @@
+# High-Level Architecture
+
+This document summarizes the architecture of the Collaborative SLAM Exploration proof-of-concept. The PoC demonstrates how a Celery-driven saga orchestrates Redis stream based command handlers to coordinate multi-robot exploration workflows.
+
+## System Context
+
+The solution is triggered when an external operator emits a `mission:start` command. The asynchronous command listener routes the event to the saga orchestrator, which dispatches Celery tasks and compensations through Redis. Handlers emit multi-stage progress updates so that mission control can observe state through Flower and the Redis replies stream.
+
+```mermaid
+%%{init: {'theme': 'neutral'}}%%
+flowchart TD
+    Operator([Mission Operator]):::actor
+    Control([Mission Control Tools]):::actor
+    subgraph System[Collaborative SLAM Orchestrator]
+        Orchestrator[Saga Orchestrator]
+        CeleryWorker[Celery Task Worker]
+        RedisBroker[(Redis Streams & Broker)]
+        Pg[(PostgreSQL State)]
+        Flower[[Flower Monitoring UI]]
+    end
+
+    Operator -->|Trigger mission:start| Orchestrator
+    Orchestrator -->|Publish command| RedisBroker
+    RedisBroker -->|Deliver tasks| CeleryWorker
+    CeleryWorker -->|Update mission state| Pg
+    CeleryWorker -->|Emit progress replies| RedisBroker
+    RedisBroker -->|Surface telemetry| Control
+    Flower -->|Read task events| RedisBroker
+    Control -->|Inspect task timeline| Flower
+
+    classDef actor fill:#f6f6f6,stroke:#333,stroke-width:1px;
+```
+
+### Key Responsibilities
+
+- **Saga Orchestrator** – Builds the Celery canvas that sequences mission tasks and compensations. 【F:app/flows/mission_start_celery/orchestrator.py†L21-L56】
+- **Celery Worker** – Hosts mission tasks and their compensating actions, delegating execution to Redis stream command handlers. 【F:app/flows/mission_start_celery/tasks.py†L13-L87】
+- **Command Listener** – Discovers handler modules dynamically and consumes Redis streams to invoke them. 【F:app/commands/listener.py†L15-L113】
+- **Redis Utilities** – Provide request/reply behavior and multi-stage progress reporting for handlers. 【F:app/redis_utils/decorators.py†L1-L58】
+- **Monitoring** – Flower attaches to the Redis broker to visualize task life cycles.
+
+## Component Structure
+
+The PoC is organized into well-defined layers: orchestration flows, task definitions, command handlers, and Redis utilities. The following component diagram highlights the internal structure.
+
+```mermaid
+%%{init: {'theme': 'neutral'}}%%
+graph LR
+    subgraph Flows
+        Orchestrator[Mission Start Orchestrator]
+        Tasks[Celery Tasks]
+    end
+
+    subgraph Commands
+        Listener[Async Command Listener]
+        Handlers[Mission Command Handlers]
+    end
+
+    subgraph RedisLayer[Redis Utilities]
+        RequestReply[request_and_reply]
+        MultiStage[multi_stage_reply]
+    end
+
+    Orchestrator -->|chain.apply_async| Tasks
+    Tasks -->|request_and_reply| Listener
+    Listener -->|xreadgroup| Redis[(Redis Streams)]
+    Handlers -->|multi_stage_reply| Redis
+    MultiStage --> Handlers
+    RequestReply --> Redis
+    Tasks --> Pg[(PostgreSQL)]
+    Tasks --> Flower
+    Orchestrator --> Flower
+```
+
+### Interaction Notes
+
+1. The orchestrator chains mission steps with compensations using Celery's canvas primitives. 【F:app/flows/mission_start_celery/orchestrator.py†L27-L50】
+2. Each task translates Celery calls into Redis stream requests handled by async listeners. 【F:app/flows/mission_start_celery/tasks.py†L18-L75】
+3. Handlers leverage the `multi_stage_reply` decorator to send start, progress, completed, and failed events. 【F:app/redis_utils/decorators.py†L9-L58】【F:app/commands/handlers/plan_route.py†L1-L25】
+4. The listener manages consumer groups and ack loops to scale independently. 【F:app/commands/listener.py†L42-L108】
+
+## Saga Execution Sequence
+
+The diagram below shows how a successful mission start flows through the system. Failure paths trigger compensations by linking Celery error callbacks; this behavior mirrors the same message exchanges with compensation tasks.
+
+```mermaid
+%%{init: {'theme': 'neutral'}}%%
+sequenceDiagram
+    participant Operator
+    participant Listener as Command Listener
+    participant Orchestrator as Celery Orchestrator
+    participant Redis as Redis Streams/Broker
+    participant Worker as Celery Worker
+    participant Handler as Async Handler
+    participant Flower
+
+    Operator->>Listener: mission:start event on mission:commands
+    Listener->>Orchestrator: call run_saga(correlation_id,...)
+    Orchestrator->>Worker: apply_async(chain)
+    Worker->>Redis: request_and_reply(resources:allocate)
+    Redis->>Handler: deliver allocate command
+    Handler->>Redis: emit start/progress/completed
+    Redis->>Worker: reply with allocation result
+    Worker->>Redis: request_and_reply(routing:plan)
+    Redis->>Handler: deliver plan command
+    Handler->>Redis: emit progress and completion
+    Worker->>Flower: task state updates via broker events
+    Worker->>Redis: request_and_reply(exploration:perform)
+    Worker->>Redis: request_and_reply(map:integrate)
+    Worker->>Worker: release_resources compensation at end
+    Flower->>Operator: visualize saga status
+```
+
+### Failure Handling
+
+- Each saga step attaches a `link_error` callback that enqueues compensating Celery tasks when a downstream task fails. 【F:app/flows/mission_start_celery/orchestrator.py†L32-L49】
+- Handlers surface failure details in the Redis reply stream, enabling upstream retries or abort logic.
+
+## Deployment Considerations
+
+- All services run inside Docker Compose with Redis, PostgreSQL, Celery workers, and Flower containers.
+- The orchestrator waits for Redis availability at startup to avoid race conditions. 【F:app/celery_app.py†L13-L30】
+- Command listeners register consumer groups idempotently, making scaling straightforward. 【F:app/commands/listener.py†L64-L92】
+
+## Observability
+
+- Flower consumes Celery events from Redis, providing task-level insight.
+- Redis reply streams include structured progress percentages and payloads for mission dashboards.
+

--- a/docs/lessons_learned.md
+++ b/docs/lessons_learned.md
@@ -1,0 +1,68 @@
+# Lessons Learned and Implementation Playbook
+
+This proof-of-concept validated that Celery, Redis Streams, and async command handlers can orchestrate a compensating saga for collaborative SLAM missions. The steps below capture the repeatable approach and key insights needed to reproduce the architecture in another domain.
+
+## 1. Frame the Workflow as a Saga
+
+1. Identify mission phases and matching compensations; represent each step as a Celery task or async function.
+2. Build a chain with explicit `link_error` callbacks so compensations fire automatically when downstream tasks fail. 【F:app/flows/mission_start_celery/orchestrator.py†L32-L50】
+3. Generate saga-scoped correlation IDs to trace every command and reply. 【F:app/flows/mission_start_celery/orchestrator.py†L23-L31】
+
+**Insight:** Treat compensations as first-class Celery tasks. This keeps orchestration declarative and makes failure handling observable through Flower.
+
+## 2. Decouple Work through Redis Streams
+
+1. Publish commands with `request_and_reply` so Celery tasks and async handlers communicate via Redis Streams. 【F:app/flows/mission_start_celery/tasks.py†L18-L78】
+2. Use consumer groups per handler to enable horizontal scaling without duplicate processing. 【F:app/commands/listener.py†L64-L92】
+3. Embrace timeouts in the request/reply helper to guard against hung handlers. 【F:app/flows/mission_start_celery/tasks.py†L22-L30】
+
+**Insight:** Redis Streams give durable back-pressure and replay semantics, which simplified our recovery strategy compared to transient queues.
+
+## 3. Standardize Handler Telemetry
+
+1. Wrap every handler with `multi_stage_reply` to emit start, progress, completed, and failed events. 【F:app/redis_utils/decorators.py†L9-L58】
+2. Pass the reply stream name through command payloads so handlers can push status updates to the correct channel. 【F:app/flows/mission_start_celery/tasks.py†L20-L72】
+3. Surface fractional progress to unlock richer mission dashboards and automated retries.
+
+**Insight:** A uniform decorator drastically reduced boilerplate and made monitoring symmetrical across services.
+
+## 4. Keep the Listener Lightweight and Idempotent
+
+1. Discover handler modules dynamically to eliminate manual registration drift. 【F:app/commands/listener.py†L18-L39】
+2. Create consumer groups on startup but tolerate BUSYGROUP errors so restarts stay idempotent. 【F:app/commands/listener.py†L70-L87】
+3. Acknowledge messages only after handlers succeed; log failures to aid replay.
+
+**Insight:** The listener forms the boundary between Celery orchestration and async services. Keeping it stateless lets us scale more listeners when mission load grows.
+
+## 5. Provide Alternate Execution Paths for Testing
+
+1. Mirror the Celery saga with a pure-async orchestrator to run deterministic tests without workers. 【F:app/flows/mission_start_async/orchestrator.py†L1-L96】
+2. Reuse the same `request_and_reply` contract so both backends exercise identical handlers. 【F:app/flows/mission_start_async/orchestrator.py†L40-L80】
+3. Trigger the desired backend through the `mission:start` handler's `backend` parameter for scenario coverage. 【F:app/commands/handlers/start_mission.py†L24-L47】
+
+**Insight:** Offering a Celery and pure-async path de-risks orchestration changes by enabling test suites that avoid worker scheduling variability.
+
+## 6. Containerize the Runtime Early
+
+1. Compose Redis, PostgreSQL, Celery workers, Flower, and the listener in Docker Compose to codify infrastructure. 【F:docker-compose.yml†L1-L74】
+2. Gate service startup on health checks to guarantee Redis is ready before Celery workers boot. 【F:docker-compose.yml†L23-L34】
+3. Mount the application directory for rapid inner-loop iteration while retaining container parity.
+
+**Insight:** The Compose stack doubles as both development and integration-test environment, ensuring parity and shortening feedback loops.
+
+## 7. Make Observability a First-Class Concern
+
+1. Enable Celery event tracking (`-E`) so Flower captures task lifecycle events. 【F:docker-compose.yml†L23-L34】
+2. Emit structured telemetry via Redis replies for mission dashboards and audit trails. 【F:app/redis_utils/decorators.py†L24-L55】
+3. Log correlation IDs at every layer to map saga progress across systems. 【F:app/flows/mission_start_celery/orchestrator.py†L23-L31】
+
+**Insight:** Observability requirements shape the contract between orchestrator, tasks, and handlers; designing telemetry up front prevents opaque failure modes.
+
+## 8. Testing Checklist
+
+- Run the async orchestrator in isolation to validate handler logic deterministically. 【F:app/flows/mission_start_async/orchestrator.py†L1-L96】
+- Execute Celery-based sagas inside Docker Compose and inspect Flower for task flow regressions. 【F:docker-compose.yml†L23-L34】
+- Add integration tests that push commands onto Redis Streams and assert replies to cover the end-to-end contract. 【F:tests/integration/test_orchestrator_trigger.py†L1-L88】
+
+**Insight:** A layered testing strategy (async unit tests + Celery integration tests) keeps the saga reproducible and debuggable.
+


### PR DESCRIPTION
## Summary
- add a high-level architecture document with Mermaid diagrams and component descriptions
- capture the lessons learned playbook for reproducing the saga approach
- refresh the README with accurate setup, usage, and testing guidance

## Testing
- not run (documentation updates only)

ref: #1

------
https://chatgpt.com/codex/tasks/task_e_68d4539323008323b319a4cc4164812b